### PR TITLE
Run action using Node.js v24

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -16,5 +16,5 @@ inputs:
     description: 'A prefix to add to the release tag. This can be used releases multiple components in the same repo.'
     required: false
 runs:
-  using: 'node12'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
Node.js v12 has long been EOL and isn't officially supported by GitHub Actions any more. Run the action using Node.js v24, the latest LTS release.