### PR TITLE
Output `release-created`, `release-tag` and `release-id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,13 @@ jobs:
 ```
 
 This will result in tags like `tools-vX.X.X` from the `Release tools` step, and `vX.X.X` for the main `Release` step.
+
+## Outputs
+
+The action produces the following outputs for use by subsequent steps:
+
+| Name | Description | Example |
+| - | - | - |
+| `release-created` | `true` if the action created a GitHub release, or `false` if it did not. | `true` |
+| `release-tag` | If a release was created, the name of the tag created for the release in the repository. | `v1.2.3` |
+| `release-id` | If a release was created, the ID assigned to the release by GitHub. This ID uniquely identifies the release in several [GitHub API endpoints](https://docs.github.com/en/rest/releases/releases). | `42` |

--- a/src/release.js
+++ b/src/release.js
@@ -6,6 +6,10 @@ const fs = require('fs')
 const crypto = require("crypto")
 const path = require('path')
 
+const RELEASE_CREATED_OUTPUT_NAME = "release-created"
+const RELEASE_TAG_OUTPUT_NAME = "release-tag"
+const RELEASE_ID_OUTPUT_NAME = "release-id"
+
 function hash(data, name) {
     const hash = crypto.createHash("sha256")
     hash.write(data)
@@ -73,7 +77,12 @@ async function run() {
 
             uploadUrl = createReleaseResp.data.upload_url
             releaseId = createReleaseResp.data.id
+
+            core.setOutput(RELEASE_CREATED_OUTPUT_NAME, true)
+            core.setOutput(RELEASE_TAG_OUTPUT_NAME, releaseName)
+            core.setOutput(RELEASE_ID_OUTPUT_NAME, releaseId)
         } else {
+            core.setOutput(RELEASE_CREATED_OUTPUT_NAME, false)
             console.log("Release already created. Nothing to do.")
             return
         }


### PR DESCRIPTION
Define the `release-created`, `release-tag` and `release-id` action outputs. The main use cases for these are to allow subsequent steps/jobs to be skipped if a release was not created (by checking the value of `release-created`) and to interact with the newly-created release in some way (via either `release-tag` or `release-id`).